### PR TITLE
Rework index page and move text

### DIFF
--- a/about.txt
+++ b/about.txt
@@ -3,6 +3,37 @@
 About the LEDE project
 ======================
 
+== A reboot of the OpenWrt community
+
+The LEDE project is founded as a spin-off of the OpenWrt project and shares many of the same goals.
+We are building an embedded Linux distribution that makes it easy for developers, system administrators or other Linux enthusiasts to build and customize software for embedded devices, especially wireless routers.
+The name 'LEDE' stands for 'Linux Embedded Development Environment'.
+
+Members of the project already include a significant share of the most active members of the OpenWrt community.
+We intend to bring new life to Embedded Linux development by creating a community with a strong focus on transparency, collaboration and decentralisation.
+
+LEDE’s stated goals are:
+
+* Building a great embedded Linux distribution with focus on stability and functionality.
+* Having regular, predictable release cycles coupled with community provided device testing feedback.
+* Establishing transparent decision processes with broad community participation and public meetings.
+
+We decided to create this new project because of long standing issues that we were unable to fix from within the OpenWrt project/community:
+
+. Number of active core developers at an all time low, no process for getting more new people involved.
+. Unreliable infrastructure, fixes prevented by internal disagreements and single points of failure.
+. Lack of communication, transparency and coordination in the OpenWrt project, both inside the core team and between the core team and the rest of the community.
+. Not enough people with commit access to handle the incoming flow of patches, too little attention to testing and regular builds.
+. Lack of focus on stability and documentation.
+
+To address these issues we set up the LEDE project in a different way compared to OpenWrt:
+
+. All our communication channels are public, some read-only to non-members to maintain a good signal-to-noise ratio.
+. Our decision making process is more open, with an approximate 50/50 mix of developers and power users with voting rights.
+. Our infrastructure is simplified a lot, to ensure that it creates less maintenance work for us.
+. We have made our merge policy more liberal, based on our experience with the OpenWrt package github feed.
+. We have a strong focus on automated testing combined with a simplified release process.
+
 == Name
 
 image:logo/logo.png["The LEDE logo",role="left"]

--- a/index.txt
+++ b/index.txt
@@ -1,38 +1,50 @@
 ---
 ---
-Welcome to the LEDE project
-===========================
+LEDE - Linux Embedded Development Environment
+=============================================
 
-== Introducing the LEDE project - A reboot of the OpenWrt community
+== Welcome to the LEDE project
 
-The LEDE project is founded as a spin-off of the OpenWrt project and shares many of the same goals.
-We are building an embedded Linux distribution that makes it easy for developers, system administrators or other Linux enthusiasts to build and customize software for embedded devices, especially wireless routers.
-The name 'LEDE' stands for 'Linux Embedded Development Environment'.
+The LEDE project is a Linux based embedded meta distribution based on OpenWrt
+and targeting a wide range of wireless SOHO routers and non-network devices.
 
-Members of the project already include a significant share of the most active members of the OpenWrt community.
-We intend to bring new life to Embedded Linux development by creating a community with a strong focus on transparency, collaboration and decentralisation.
+LEDE spun away from the mother project in May 2016, aims for an open governance
+model and attempts to simplify contributing to encourage new developers in
+embedded development.
 
-LEDE’s stated goals are:
+Refer to our link:about.html[about page] to learn more about the projects
+origins.
 
-* Building a great embedded Linux distribution with focus on stability and functionality.
-* Having regular, predictable release cycles coupled with community provided device testing feedback.
-* Establishing transparent decision processes with broad community participation and public meetings.
+=== How can I use LEDE?
 
-We decided to create this new project because of long standing issues that we were unable to fix from within the OpenWrt project/community:
+Since LEDE is a pretty young spinoff from OpenWrt it is largely compatible to
+it, in most cases the same installation procedures can be used to flash your
+devices.
 
-. Number of active core developers at an all time low, no process for getting more new people involved.
-. Unreliable infrastructure, fixes prevented by internal disagreements and single points of failure.
-. Lack of communication, transparency and coordination in the OpenWrt project, both inside the core team and between the core team and the rest of the community.
-. Not enough people with commit access to handle the incoming flow of patches, too little attention to testing and regular builds.
-. Lack of focus on stability and documentation.
+Sysupgrades from OpenWrt to LEDE or vice versa are supported but it is advised
+to not keep settings in such a case to benefit from the updated defaults.
 
-To address these issues we set up the LEDE project in a different way compared to OpenWrt:
+=== What is LEDE’s target audience?
 
-. All our communication channels are public, some read-only to non-members to maintain a good signal-to-noise ratio.
-. Our decision making process is more open, with an approximate 50/50 mix of developers and power users with voting rights.
-. Our infrastructure is simplified a lot, to ensure that it creates less maintenance work for us.
-. We have made our merge policy more liberal, based on our experience with the OpenWrt package github feed.
-. We have a strong focus on automated testing combined with a simplified release process.
+As a source based Linux distribution for wireless routers, LEDE is primarily
+intented for networking enthusiasts, wireless communities, embedded Linux
+developers and advanced users.
+
+LEDE aims for versatility and ease of customization but does not attempt to
+be a fully integrated alternative to OEM firmware, it rather is a set of
+building blocks to implement your own projects.
+
+=== How can I help?
+
+Like any open source project, LEDE lives from the effort being put into it by
+its users and developers. If you like to participate in development, please
+refer to our link:development.html[development sub page] to learn more about
+source code access and building instructions.
+
+If you do not consider yourself a developer but want to participate in
+maintaining documentation or in helping community members then don't hesitate
+to join our http://lists.infradead.org/mailman/listinfo/lede-dev[mailing list]
+or IRC channels to get in touch.
 
 === Endorsement
 


### PR DESCRIPTION
Move most text parts of the index page to about and rework the front page to be more approachable.

Signed-off-by: Jo-Philipp Wich jo@mein.io
