### PR TITLE
Fixes misplaced "firewall" reference.

### DIFF
--- a/docs/uci_dropbear.txt
+++ b/docs/uci_dropbear.txt
@@ -5,7 +5,7 @@ Dropbear Configuration
 
 == Dropbear Configuration
 
-The firewall configuration located in **'/etc/config/dropbear'**.
+The Dropbear UCI configuration file is located in **'/etc/config/dropbear'**.
 
 == Sections
 


### PR DESCRIPTION
Prior to this commit the Dropbear configuration docs page accidentally
refers to the "firewall configuration" when it means the "Dropbear
configuration".

Signed-off-by: cpu daniel@binaryparadox.net
